### PR TITLE
トピック ポートフォリオサイトの見直しと更新-fuma_ru【メインページのテキストの位置調整_css】

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -263,7 +263,7 @@ main img {
   }
 
   .work__ul li .btn {
-    padding: 85px 0;
+    padding: 90px 0;
     font-size: 1.5rem;
   }
 


### PR DESCRIPTION
スマホレイアウトでのボタン上の文字位置がズレていたので上下中央に調整しました。

#1